### PR TITLE
Add ADMBA 3D developing mouse atlases

### DIFF
--- a/bg_atlasgen/atlas_scripts/admba_3d_dev_mouse.py
+++ b/bg_atlasgen/atlas_scripts/admba_3d_dev_mouse.py
@@ -302,7 +302,7 @@ if __name__ == "__main__":
         resolution=(16, 16, 20),
         citation="Young et al. 2021, https://doi.org/10.7554/eLife.61408",
         root_id=15564,
-        atlas_packager="Pradeep Rajasekhar, WEHI, Australia, rajasekhardotp@wehidotedudotau",
+        atlas_packager="Pradeep Rajasekhar, WEHI, Australia, rajasekhardotp@wehidotedudotau; David Young, UCSF, United States, davedotyoung@ucsfdotedu",
     )
 
     # E13.5 atlas, with updated name and URLs

--- a/bg_atlasgen/atlas_scripts/admba_3d_dev_mouse.py
+++ b/bg_atlasgen/atlas_scripts/admba_3d_dev_mouse.py
@@ -1,0 +1,377 @@
+__version__ = "0"
+
+import dataclasses
+import json
+import time
+import zipfile
+
+from os import listdir, path
+from typing import Tuple
+
+import pandas as pd
+import numpy as np
+import multiprocessing as mp
+
+from rich.progress import track
+from pathlib import Path
+
+from bg_atlasapi import utils
+from bg_atlasgen.mesh_utils import create_region_mesh, Region
+from bg_atlasgen.wrapup import wrapup_atlas_from_data
+from bg_atlasapi.structure_tree_util import get_structures_tree
+
+from skimage import io
+
+PARALLEL = True
+
+
+def download_atlas_files(download_dir_path, atlas_file_url, ATLAS_NAME):
+    utils.check_internet_connection()
+    
+    atlas_files_dir = download_dir_path / ATLAS_NAME
+    try:
+        download_name = ATLAS_NAME + "_atlas.zip"
+    except TypeError:
+        download_name = ATLAS_NAME / "_atlas.zip"
+    destination_path = download_dir_path / download_name
+    utils.retrieve_over_http(atlas_file_url, destination_path)
+    
+    with zipfile.ZipFile(destination_path, "r") as zip_ref:
+        zip_ref.extractall(atlas_files_dir)
+    
+    return atlas_files_dir
+
+
+def parse_structures(structures_file, root_id):
+    df = pd.read_csv(structures_file)
+    df = df.rename(columns={"Parent": "parent_structure_id"})
+    df = df.rename(columns={"Region": "id"})
+    df = df.rename(columns={"RegionName": "name"})
+    df = df.rename(columns={"RegionAbbr": "acronym"})
+    df = df.drop(columns=["Level"])
+    # get length of labels so as to generate rgb values
+    no_items = df.shape[0]
+    # Random values for RGB
+    # could use this instead?
+    rgb_list = [[
+        np.random.randint(0, 255), np.random.randint(0, 255),
+        np.random.randint(0, 255)] for i in range(no_items)]
+    rgb_list = pd.DataFrame(rgb_list, columns=['red', 'green', 'blue'])
+    
+    df["rgb_triplet"] = rgb_list.apply(
+        lambda x: [x.red.item(), x.green.item(), x.blue.item()], axis=1)
+    df["structure_id_path"] = df.apply(lambda x: [x.id], axis=1)
+    structures = df.to_dict("records")
+    structures = create_structure_hierarchy(structures, df, root_id)
+    return structures
+
+
+def create_structure_hierarchy(structures, df, root_id):
+    for structure in structures:
+        if structure["id"] != root_id:
+            parent_id = structure["parent_structure_id"]
+            while True:
+                structure["structure_id_path"] = [parent_id] + structure[
+                    "structure_id_path"
+                ]
+                if parent_id != root_id:
+                    parent_id = int(
+                        df[df["id"] == parent_id]["parent_structure_id"]
+                    )
+                else:
+                    break
+        else:
+            structure["name"] = "root"
+            structure["acronym"] = "root"
+        
+        del structure["parent_structure_id"]
+    
+    return structures
+
+
+def create_meshes(download_dir_path, structures, annotated_volume, root_id):
+    meshes_dir_path = download_dir_path / "meshes"
+    meshes_dir_path.mkdir(exist_ok=True)
+    
+    tree = get_structures_tree(structures)
+    
+    labels = np.unique(annotated_volume).astype(np.int32)
+    
+    for key, node in tree.nodes.items():
+        if key in labels:
+            is_label = True
+        else:
+            is_label = False
+        node.data = Region(is_label)
+    
+    # Mesh creation
+    closing_n_iters = 2
+    decimate_fraction = 0.2
+    smooth = False  # smooth meshes after creation
+    start = time.time()
+    if PARALLEL:
+        
+        pool = mp.Pool(mp.cpu_count() - 2)
+        
+        try:
+            pool.map(
+                create_region_mesh,
+                [
+                    (
+                        meshes_dir_path,
+                        node,
+                        tree,
+                        labels,
+                        annotated_volume,
+                        root_id,
+                        closing_n_iters,
+                        decimate_fraction,
+                        smooth,
+                    )
+                    for node in tree.nodes.values()
+                ],
+            )
+        except mp.pool.MaybeEncodingError:
+            pass
+    else:
+        for node in track(
+                tree.nodes.values(),
+                total=tree.size(),
+                description="Creating meshes",
+        ):
+            create_region_mesh(
+                (
+                    meshes_dir_path,
+                    node,
+                    tree,
+                    labels,
+                    annotated_volume,
+                    root_id,
+                    closing_n_iters,
+                    decimate_fraction,
+                    smooth,
+                )
+            )
+    
+    print(
+        "Finished mesh extraction in: ",
+        round((time.time() - start) / 60, 2),
+        " minutes",
+    )
+    return meshes_dir_path
+
+
+def create_mesh_dict(structures, meshes_dir_path):
+    meshes_dict = dict()
+    structures_with_mesh = []
+    for s in structures:
+        # Check if a mesh was created
+        mesh_path = meshes_dir_path / f'{s["id"]}.obj'
+        if not mesh_path.exists():
+            print(f"No mesh file exists for: {s}, ignoring it")
+            continue
+        else:
+            # Check that the mesh actually exists (i.e. not empty)
+            if mesh_path.stat().st_size < 512:
+                print(f"obj file for {s} is too small, ignoring it.")
+                continue
+        
+        structures_with_mesh.append(s)
+        meshes_dict[s["id"]] = mesh_path
+    
+    print(
+        f"In the end, {len(structures_with_mesh)} structures with mesh are kept"
+    )
+    return meshes_dict, structures_with_mesh
+
+
+@dataclasses.dataclass
+class AtlasConfig:
+    """Data class to configure atlas creation."""
+    atlas_name: str
+    species: str
+    atlas_link: str
+    atlas_file_url: str
+    orientation: str
+    resolution: Tuple[float, float, float]
+    citation: str
+    root_id: int
+    atlas_packager: str
+
+
+def create_atlas(working_dir: Path = Path.home(),
+                 atlas_config: "AtlasConfig" = None):
+    assert len(atlas_config.orientation) == 3, \
+        f"Orientation is not 3 characters, Got {atlas_config.orientation}"
+    assert len(atlas_config.resolution) == 3, \
+        f"Resolution is not correct, Got {atlas_config.resolution}"
+    assert atlas_config.atlas_file_url, \
+        f"No download link provided for atlas in {atlas_config.atlas_file_url}"
+    if type(working_dir) == str:
+        working_dir = Path(working_dir)
+    # Generated atlas path:
+    working_dir = (working_dir / "brainglobe_workingdir" /
+                   atlas_config.atlas_name)
+    working_dir.mkdir(exist_ok=True, parents=True)
+    
+    download_dir_path = working_dir / "downloads"
+    download_dir_path.mkdir(exist_ok=True)
+    if path.isdir(atlas_config.atlas_file_url):
+        print("Setting atlas to directory: ", atlas_config.atlas_file_url)
+        atlas_files_dir = atlas_config.atlas_file_url
+    else:
+        # Download atlas files from link provided
+        print("Downloading atlas from link: ", atlas_config.atlas_file_url)
+        atlas_files_dir = download_atlas_files(
+            download_dir_path, atlas_config.atlas_file_url,
+            atlas_config.atlas_name)
+        ## Load files
+    
+    structures_file = atlas_files_dir / (
+        [f for f in listdir(atlas_files_dir) if "region_ids_ADMBA" in f][0])
+    
+    reference_file = atlas_files_dir / (
+        [f for f in listdir(atlas_files_dir) if "atlasVolume.mhd" in f][0])
+    
+    annotations_file = atlas_files_dir / (
+        [f for f in listdir(atlas_files_dir) if "annotation.mhd" in f][0])
+    # segments_file = atlas_files_dir / "Segments.csv"
+    
+    annotated_volume = io.imread(annotations_file)
+    template_volume = io.imread(reference_file)
+    
+    ## Parse structure metadata
+    structures = parse_structures(structures_file, atlas_config.root_id)
+    
+    # save regions list json:
+    with open(download_dir_path / "structures.json", "w") as f:
+        json.dump(structures, f)
+    
+    # Create meshes:
+    print(f"Saving atlas data at {download_dir_path}")
+    meshes_dir_path = create_meshes(
+        download_dir_path, structures, annotated_volume, atlas_config.root_id
+    )
+    
+    meshes_dict, structures_with_mesh = create_mesh_dict(
+        structures, meshes_dir_path
+    )
+    
+    # Wrap up, compress, and remove file:
+    print("Finalising atlas")
+    output_filename = wrapup_atlas_from_data(
+        atlas_name=atlas_config.atlas_name,
+        atlas_minor_version=__version__,
+        citation=atlas_config.citation,
+        atlas_link=atlas_config.atlas_link,
+        species=atlas_config.species,
+        resolution=atlas_config.resolution,
+        orientation=atlas_config.orientation,
+        root_id=atlas_config.root_id,
+        reference_stack=template_volume,
+        annotation_stack=annotated_volume,
+        structures_list=structures_with_mesh,
+        meshes_dict=meshes_dict,
+        working_dir=working_dir,
+        atlas_packager=atlas_config.atlas_packager,
+        hemispheres_stack=None,
+        cleanup_files=False,
+        compress=True,
+        scale_meshes=True
+    )
+    print("Done. Atlas generated at: ", output_filename)
+    return output_filename
+
+
+if __name__ == "__main__":
+    # Generated atlas path:
+    bg_root_dir = Path.home() / "brainglobe_workingdir"
+    bg_root_dir.mkdir(exist_ok=True, parents=True)
+    
+    # set up E11.5 atlas settings and use as template for rest of brains
+    e11_5_config = AtlasConfig(
+        atlas_name="admba_3d_e11_5_mouse",
+        species="Mus musculus",
+        atlas_link="https://search.kg.ebrains.eu/instances/8ab25629-bdac-47d0-bc86-6f3aa3885f29",
+        atlas_file_url="https://data.kg.ebrains.eu/zip?container=https://object.cscs.ch/v1/AUTH_4791e0a3b3de43e2840fe46d9dc2b334/ext-d000023_3Drecon-ADMBA-E11pt5_pub",
+        orientation="pir",
+        resolution=(16, 16, 20),
+        citation="Young et al. 2021, https://doi.org/10.7554/eLife.61408",
+        root_id=15564,
+        atlas_packager="Pradeep Rajasekhar, WEHI, Australia, rajasekhardotp@wehidotedudotau",
+    )
+
+    # E13.5 atlas, with updated name and URLs
+    e13_5_config = dataclasses.replace(
+        e11_5_config,
+        atlas_name="admba_3d_e13_5_mouse",
+        atlas_link="https://search.kg.ebrains.eu/instances/bdb89f61-8dc4-4255-b4d5-50d470958b58",
+        atlas_file_url="https://data.kg.ebrains.eu/zip?container=https://object.cscs.ch/v1/AUTH_4791e0a3b3de43e2840fe46d9dc2b334/ext-d000024_3Drecon-ADMBA-E13pt5_pub",
+    )
+
+    # E15.5 atlas
+    e15_5_config = dataclasses.replace(
+        e11_5_config,
+        atlas_name="admba_3d_e15_5_mouse",
+        atlas_link="https://search.kg.ebrains.eu/instances/Dataset/51a81ae5-d821-437a-a6d5-9b1f963cfe9b",
+        atlas_file_url="https://data.kg.ebrains.eu/zip?container=https://object.cscs.ch/v1/AUTH_4791e0a3b3de43e2840fe46d9dc2b334/ext-d000025_3Drecon-ADMBA-E15pt5_pub",
+    )
+
+    # E18.5 atlas
+    e18_5_config = dataclasses.replace(
+        e11_5_config,
+        atlas_name="admba_3d_e18_5_mouse",
+        atlas_link="https://search.kg.ebrains.eu/instances/633b41be-867a-4611-8570-82271aebd516",
+        atlas_file_url="https://data.kg.ebrains.eu/zip?container=https://object.cscs.ch/v1/AUTH_4791e0a3b3de43e2840fe46d9dc2b334/ext-d000026_3Drecon-ADMBA-E18pt5_pub",
+    )
+
+    # P4 atlas, which has different resolutions
+    p4_config = dataclasses.replace(
+        e11_5_config,
+        atlas_name="admba_3d_p4_mouse",
+        atlas_link="https://search.kg.ebrains.eu/instances/eea3589f-d74b-4988-8f4c-fd9ae8e3a4b3",
+        atlas_file_url="https://data.kg.ebrains.eu/zip?container=https://object.cscs.ch/v1/AUTH_4791e0a3b3de43e2840fe46d9dc2b334/ext-d000027_3Drecon-ADMBA-P4_pub",
+        resolution=(16.752, 16.752, 20),
+    )
+
+    # P14 atlas, which has slightly different resolutions
+    p14_config = dataclasses.replace(
+        e11_5_config,
+        atlas_name="admba_3d_p14_mouse",
+        atlas_link="https://search.kg.ebrains.eu/instances/114e50aa-156c-4283-af73-11b7f03d287e",
+        atlas_file_url="https://data.kg.ebrains.eu/zip?container=https://object.cscs.ch/v1/AUTH_4791e0a3b3de43e2840fe46d9dc2b334/ext-d000028_3Drecon-ADMBA-P14_pub",
+        resolution=(16.752, 16.752, 25),
+    )
+
+    # P28 atlas, which has same resolutions as P14
+    p28_config = dataclasses.replace(
+        p14_config,
+        atlas_name="admba_3d_p28_mouse",
+        atlas_link="https://search.kg.ebrains.eu/instances/3a1153f0-6779-43bd-9f02-f92700a585a4",
+        atlas_file_url="https://data.kg.ebrains.eu/zip?container=https://object.cscs.ch/v1/AUTH_4791e0a3b3de43e2840fe46d9dc2b334/ext-d000029_3Drecon-ADMBA-P28_pub",
+    )
+
+    # P56 atlas, which has different resolutions
+    p56_config = dataclasses.replace(
+        e11_5_config,
+        atlas_name="admba_3d_p56_mouse",
+        atlas_link="https://search.kg.ebrains.eu/instances/a7e99105-1ec2-42e2-a53a-7aa0f2b78135",
+        atlas_file_url="https://data.kg.ebrains.eu/zip?container=https://object.cscs.ch/v1/AUTH_4791e0a3b3de43e2840fe46d9dc2b334/ext-d000030_3Drecon-ADMBA-P56_pub",
+        resolution=(25, 25, 25),
+    )
+    
+    # atlases to create
+    configs = (
+        e11_5_config,
+        e13_5_config,
+        e15_5_config,
+        e18_5_config,
+        p4_config,
+        p14_config,
+        p28_config,
+        p56_config,
+    )
+    
+    # create each atlas
+    for config in configs:
+        create_atlas(bg_root_dir, config)

--- a/bg_atlasgen/atlas_scripts/admba_3d_dev_mouse.py
+++ b/bg_atlasgen/atlas_scripts/admba_3d_dev_mouse.py
@@ -192,7 +192,11 @@ class AtlasConfig:
     species: str
     atlas_link: str
     atlas_file_url: str
+    #: Input orientation in 3-letter notation using the NumPy system with origin
+    #: at top left corner of first plane. Axis 0 = front to back, 1 = top to
+    #: bottom, 2 = left to right. Output orientation will be ASR.
     orientation: str
+    #: Resolution to match the output orientation of ASR.
     resolution: Tuple[float, float, float]
     citation: str
     root_id: int
@@ -294,7 +298,7 @@ if __name__ == "__main__":
         species="Mus musculus",
         atlas_link="https://search.kg.ebrains.eu/instances/8ab25629-bdac-47d0-bc86-6f3aa3885f29",
         atlas_file_url="https://data.kg.ebrains.eu/zip?container=https://object.cscs.ch/v1/AUTH_4791e0a3b3de43e2840fe46d9dc2b334/ext-d000023_3Drecon-ADMBA-E11pt5_pub",
-        orientation="pir",
+        orientation="lsa",
         resolution=(16, 16, 20),
         citation="Young et al. 2021, https://doi.org/10.7554/eLife.61408",
         root_id=15564,


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [x] Addition of a new feature
- [ ] Other

**Why is this PR needed?**

This PR extends the `mouse_e15_5` script by @pr4deepr in #11 to build all eight atlases in the 3D reconstructed version of the Allen Developing Mouse Brain Atlas series. Thanks for hosting these atlases!

**What does this PR do?**

This build script is essentially the same as the original version except for the addition of a data class to configure the atlas parameters, which is implemented for each atlas in the same script. I've kept @pr4deepr's name as the package author as he built the original script.

Am I correct in understanding that the atlas generator reorients the atlas from the given orientation to ASR orientation? I input the orientation as PIR while the output metadata says ASR. Original is on the left, output on the right (or is it PSR?):

![image](https://user-images.githubusercontent.com/1258953/173037405-a22fe9f1-9110-4b82-84a5-84c2920be5ff.png)

Also, are the resolutions in `x, y, z` order, and are they unchanged during atlas generation? These atlases are slightly anisotropic (same resolutions as the original), so I wanted to double-check and have listed the resolutions in this order.

## References

#11, which introduced the atlas creation script for the E15.5 atlas as well as a GUI. This current PR focuses on the atlas build script while the GUI implementation can continue in the original PR.

## How has this PR been tested?

Built and tested locally (but haven't tested the meshes). I have run into sporadic connection errors during building at times, presumably network errors with the host (eg right at the moment).

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No, but it could be useful to update the docs on the orientation and also on the resolution order for non-isotropic atlases.

## Checklist:

- [x] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
