### PR TITLE
Error on warnings raised in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,10 @@ include = ["bg_atlasgen*"]
 
 [tool.pytest.ini_options]
 addopts = "--cov=bg_atlasgen"
+filterwarnings = [
+    "error",
+]
+
 
 [tool.black]
 target-version = ['py38', 'py39', 'py310', 'py311']


### PR DESCRIPTION
This PR catches any warnings that are emitted by tests, and errors on them. This is generally good practice, to make sure the code isn't emitting any warnings, or if it is that they are intended.

I didn't find any woarnings to catch/filter here, but worth adding in case anything pops up in the future.
