### PR TITLE
Add standard pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,22 @@
 repos:
--   repo: https://github.com/python/black
-    rev: 22.12.0
-    hooks:
-    - id: black
-      pass_filenames: true
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.4.0
+      hooks:
+          - id: check-docstring-first
+          - id: check-executables-have-shebangs
+          - id: check-merge-conflict
+          - id: end-of-file-fixer
+          - id: mixed-line-ending
+            args: [--fix=lf]
+          - id: requirements-txt-fixer
+          - id: trailing-whitespace
+    - repo: https://github.com/charliermarsh/ruff-pre-commit
+      rev: v0.0.240
+      hooks:
+        - id: ruff
+          args: [ --config=pyproject.toml ]
+    - repo: https://github.com/psf/black
+      rev: 23.1.0
+      hooks:
+          - id: black
+            args: [--config=pyproject.toml]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Utilities and scripts for the generation of cleaned-up data for the `bg-atlasapi
 ### To contribute
 1) Fork this repo
 
-2) Clone your repo 
+2) Clone your repo
 ```bash
 git clone https://github.com/USERNAME/bg-atlasgen
 ```
@@ -16,16 +16,16 @@ git clone https://github.com/USERNAME/bg-atlasgen
 3) Install an editable version
 ```bash
 cd bg-atlasgen
-pip install -e . 
+pip install -e .
 ```
-4) Create a script to package your atlas, and place into 
+4) Create a script to package your atlas, and place into
 `bg_atlasgen/atlas_scripts`. Please see other scripts for examples.
 
-Your script should contain everything required to run. The raw data should be 
+Your script should contain everything required to run. The raw data should be
 hosted on a publicly accessible repository so that anyone can run the script
  to recreate the atlas.
 
-If you need to add any dependencies, please add them as an extra in the 
+If you need to add any dependencies, please add them as an extra in the
 setup.py file, e.g.:
 
 ```python

--- a/bg_atlasgen/atlas_scripts/admba_3d_dev_mouse.py
+++ b/bg_atlasgen/atlas_scripts/admba_3d_dev_mouse.py
@@ -2,25 +2,22 @@ __version__ = "0"
 
 import dataclasses
 import json
+import multiprocessing as mp
 import time
 import zipfile
-
 from os import listdir, path
+from pathlib import Path
 from typing import Tuple
 
-import pandas as pd
 import numpy as np
-import multiprocessing as mp
-
-from rich.progress import track
-from pathlib import Path
-
+import pandas as pd
 from bg_atlasapi import utils
-from bg_atlasgen.mesh_utils import create_region_mesh, Region
-from bg_atlasgen.wrapup import wrapup_atlas_from_data
 from bg_atlasapi.structure_tree_util import get_structures_tree
-
+from rich.progress import track
 from skimage import io
+
+from bg_atlasgen.mesh_utils import Region, create_region_mesh
+from bg_atlasgen.wrapup import wrapup_atlas_from_data
 
 PARALLEL = True
 
@@ -116,7 +113,6 @@ def create_meshes(download_dir_path, structures, annotated_volume, root_id):
     smooth = False  # smooth meshes after creation
     start = time.time()
     if PARALLEL:
-
         pool = mp.Pool(mp.cpu_count() - 2)
 
         try:

--- a/bg_atlasgen/atlas_scripts/allen_cord.py
+++ b/bg_atlasgen/atlas_scripts/allen_cord.py
@@ -1,31 +1,29 @@
 __version__ = "1"
 
 import json
-import time
-import tifffile
-import zipfile
-
-
-import pandas as pd
-import numpy as np
 import multiprocessing as mp
-from random import choices
-from loguru import logger
-from rich.progress import track
+import time
+import zipfile
 from pathlib import Path
+from random import choices
+
+import numpy as np
+import pandas as pd
+import tifffile
 
 # import sys
-
 # sys.path.append("./")
-
 from bg_atlasapi import utils
+from bg_atlasapi.structure_tree_util import get_structures_tree
+from loguru import logger
+from rich.progress import track
+
 from bg_atlasgen.mesh_utils import (
-    create_region_mesh,
     Region,
+    create_region_mesh,
     inspect_meshes_folder,
 )
 from bg_atlasgen.wrapup import wrapup_atlas_from_data
-from bg_atlasapi.structure_tree_util import get_structures_tree
 
 PARALLEL = True
 TEST = False
@@ -123,7 +121,7 @@ def create_meshes(download_dir_path, structures, annotated_volume, root_id):
     nodes = list(tree.nodes.values())
     if TEST:
         logger.info(
-            f"Creating atlas in test mode: selecting 10 random regions for mesh creation"
+            "Creating atlas in test mode: selecting 10 random regions for mesh creation"
         )
         nodes = choices(nodes, k=10)
 
@@ -289,7 +287,6 @@ def create_atlas(working_dir):
 
 
 if __name__ == "__main__":
-
     # Generated atlas path:
     bg_root_dir = Path.home() / "brainglobe_workingdir" / "allen_cord_smooth"
     bg_root_dir.mkdir(exist_ok=True, parents=True)

--- a/bg_atlasgen/atlas_scripts/allen_mouse.py
+++ b/bg_atlasgen/atlas_scripts/allen_mouse.py
@@ -1,15 +1,15 @@
 __version__ = "2"
 
+from pathlib import Path
+
 from allensdk.api.queries.ontologies_api import OntologiesApi
 from allensdk.api.queries.reference_space_api import ReferenceSpaceApi
 from allensdk.core.reference_space_cache import ReferenceSpaceCache
-
+from bg_atlasapi import descriptors
 from requests import exceptions
-from pathlib import Path
 from tqdm import tqdm
 
 from bg_atlasgen.wrapup import wrapup_atlas_from_data
-from bg_atlasapi import descriptors
 
 
 def create_atlas(working_dir, resolution):
@@ -83,7 +83,7 @@ def create_atlas(working_dir, resolution):
         ]
 
     # Wrap up, compress, and remove file:0
-    print(f"Finalising atlas")
+    print("Finalising atlas")
     output_filename = wrapup_atlas_from_data(
         atlas_name=ATLAS_NAME,
         atlas_minor_version=__version__,

--- a/bg_atlasgen/atlas_scripts/azba_zfish.py
+++ b/bg_atlasgen/atlas_scripts/azba_zfish.py
@@ -10,30 +10,27 @@ Script to generate a Brainglobe compatible atlas object for the Adult Zebrafish 
 __version__ = "1"
 
 import csv
-import time
-import tifffile
+import multiprocessing as mp
 import tarfile
-from random import choices
+import time
+from pathlib import Path
 
 import numpy as np
-import multiprocessing as mp
-
+import tifffile
+from bg_atlasapi import utils
+from bg_atlasapi.structure_tree_util import get_structures_tree
 from rich.progress import track
-from pathlib import Path
+
 from bg_atlasgen.mesh_utils import (
     Region,
     create_region_mesh,
-    inspect_meshes_folder,
 )
-from bg_atlasapi.structure_tree_util import get_structures_tree
 from bg_atlasgen.wrapup import wrapup_atlas_from_data
-from bg_atlasapi import utils
 
 PARALLEL = False  # Disable for debugging mesh creation
 
 
 def create_atlas(working_dir, resolution):
-
     # metadata
     ATLAS_NAME = "azba_zfish"
     SPECIES = "Danio rerio"
@@ -135,7 +132,6 @@ def create_atlas(working_dir, resolution):
     smooth = True
 
     if PARALLEL:
-
         print("Multiprocessing mesh creation...")
         pool = mp.Pool(int(mp.cpu_count() / 2))
 
@@ -159,7 +155,6 @@ def create_atlas(working_dir, resolution):
             pass
 
     else:
-
         print("Multiprocessing disabled")
         # nodes = list(tree.nodes.values())
         # nodes = choices(nodes, k=10)

--- a/bg_atlasgen/atlas_scripts/example_mouse.py
+++ b/bg_atlasgen/atlas_scripts/example_mouse.py
@@ -1,18 +1,17 @@
 __version__ = "2"
 
+from pathlib import Path
+
 from allensdk.api.queries.ontologies_api import OntologiesApi
 from allensdk.api.queries.reference_space_api import ReferenceSpaceApi
 from allensdk.core.reference_space_cache import ReferenceSpaceCache
-
 from requests import exceptions
-from pathlib import Path
 from tqdm import tqdm
 
 from bg_atlasgen.wrapup import wrapup_atlas_from_data
 
 
 def create_atlas(working_dir, resolution):
-
     # Specify information about the atlas:
     RES_UM = resolution  # 100
     ATLAS_NAME = "example_mouse"

--- a/bg_atlasgen/atlas_scripts/humanatlas.py
+++ b/bg_atlasgen/atlas_scripts/humanatlas.py
@@ -1,25 +1,25 @@
 import json
-from rich.progress import track
-import pandas as pd
-import numpy as np
-import time
 import multiprocessing as mp
+import time
 from pathlib import Path
+
+import numpy as np
+import pandas as pd
 import treelib
-from brainio import brainio
 import urllib3
 from allensdk.core.structure_tree import StructureTree
+from bg_atlasapi.structure_tree_util import get_structures_tree
+from brainio import brainio
+from rich.progress import track
 
 # import sys
-
 # sys.path.append("./")
 from bg_atlasgen.mesh_utils import (
-    create_region_mesh,
     Region,
+    create_region_mesh,
     inspect_meshes_folder,
 )
 from bg_atlasgen.wrapup import wrapup_atlas_from_data
-from bg_atlasapi.structure_tree_util import get_structures_tree
 
 
 def prune_tree(tree):

--- a/bg_atlasgen/atlas_scripts/kim_developmental_ccf_mouse.py
+++ b/bg_atlasgen/atlas_scripts/kim_developmental_ccf_mouse.py
@@ -1,24 +1,21 @@
 __version__ = "1"
 
 import json
-import time
-import tarfile
-
-import pandas as pd
-import numpy as np
 import multiprocessing as mp
-
-from rich.progress import track
+import time
+import zipfile
 from pathlib import Path
+
+import imio
+import numpy as np
+import pandas as pd
+from bg_atlasapi import utils
+from bg_atlasapi.structure_tree_util import get_structures_tree
+from rich.progress import track
 from scipy.ndimage import zoom
 
-from bg_atlasapi import utils
-from bg_atlasgen.mesh_utils import create_region_mesh, Region
+from bg_atlasgen.mesh_utils import Region, create_region_mesh
 from bg_atlasgen.wrapup import wrapup_atlas_from_data
-from bg_atlasapi.structure_tree_util import get_structures_tree
-import imio
-import zipfile
-import os
 
 PARALLEL = True  # disable parallel mesh extraction for easier debugging
 
@@ -47,7 +44,6 @@ def get_structure_id_path_from_id(id, id_dict, root_id):
         return structure_id_path
 
     while True:
-
         parent = int(id_dict[id])
         structure_id_path.insert(0, parent)
 
@@ -141,7 +137,6 @@ def create_atlas(
 
     structures = []
     for row in range(df.shape[0]):
-
         entry = {
             "acronym": df["Acronym"][row],
             "id": int(df["ID"][row]),  # from np.int for JSON serialization
@@ -184,7 +179,6 @@ def create_atlas(
         node.data = Region(is_label)
 
     if mesh_creation == "generate":
-
         closing_n_iters = 2
         decimate_fraction = 0.04
         smooth = False  # smooth meshes after creation
@@ -192,7 +186,6 @@ def create_atlas(
         start = time.time()
 
         if PARALLEL:
-
             pool = mp.Pool(mp.cpu_count() - 2)
 
             try:

--- a/bg_atlasgen/atlas_scripts/kim_mouse.py
+++ b/bg_atlasgen/atlas_scripts/kim_mouse.py
@@ -1,27 +1,25 @@
 __version__ = "1"
 
 import json
-import time
-import tarfile
-import tifffile
-
-import pandas as pd
-import numpy as np
 import multiprocessing as mp
-
-from rich.progress import track
+import tarfile
+import time
 from pathlib import Path
-from scipy.ndimage import zoom
+
+import numpy as np
+import pandas as pd
+import tifffile
 from allensdk.core.reference_space_cache import ReferenceSpaceCache
 
 # import sys
-
 # sys.path.append("./")
-
 from bg_atlasapi import utils
-from bg_atlasgen.mesh_utils import create_region_mesh, Region
-from bg_atlasgen.wrapup import wrapup_atlas_from_data
 from bg_atlasapi.structure_tree_util import get_structures_tree
+from rich.progress import track
+from scipy.ndimage import zoom
+
+from bg_atlasgen.mesh_utils import Region, create_region_mesh
+from bg_atlasgen.wrapup import wrapup_atlas_from_data
 
 PARALLEL = False  # disable parallel mesh extraction for easier debugging
 
@@ -135,7 +133,6 @@ def create_atlas(working_dir, resolution):
 
     start = time.time()
     if PARALLEL:
-
         pool = mp.Pool(mp.cpu_count() - 2)
 
         try:

--- a/bg_atlasgen/atlas_scripts/mpin_zfish.py
+++ b/bg_atlasgen/atlas_scripts/mpin_zfish.py
@@ -1,23 +1,18 @@
 __version__ = "1"
 
-from pathlib import Path
+import tarfile
 import warnings
-import zipfile
-import requests
-import tarfile
-from tifffile import imread
-from bg_atlasgen.mesh_utils import extract_mesh_from_mask
-import tarfile
 import zipfile
 from pathlib import Path
 
 import numpy as np
-from scipy.ndimage import binary_dilation, binary_erosion, binary_fill_holes
-
+import requests
 from allensdk.core.structure_tree import StructureTree
-from bg_atlasgen.wrapup import wrapup_atlas_from_data
-
 from bg_atlasapi.utils import retrieve_over_http
+from scipy.ndimage import binary_dilation, binary_erosion, binary_fill_holes
+from tifffile import imread
+
+from bg_atlasgen.wrapup import wrapup_atlas_from_data
 
 BASE_URL = r"https://fishatlas.neuro.mpg.de"
 
@@ -229,7 +224,7 @@ def create_atlas(working_dir, resolution):
         meshes_dict[sid] = extracted_dir / f"{sid}.stl"
 
     # Wrap up, compress, and remove file:0
-    print(f"Finalising atlas")
+    print("Finalising atlas")
     output_filename = wrapup_atlas_from_data(
         atlas_name=ATLAS_NAME,
         atlas_minor_version=__version__,

--- a/bg_atlasgen/atlas_scripts/osten_mouse.py
+++ b/bg_atlasgen/atlas_scripts/osten_mouse.py
@@ -1,23 +1,22 @@
 __version__ = "0"
 
 import json
-import time
-import tarfile
-import tifffile
-
-import pandas as pd
-import numpy as np
 import multiprocessing as mp
-
-from rich.progress import track
+import tarfile
+import time
 from pathlib import Path
-from scipy.ndimage import zoom
+
+import numpy as np
+import pandas as pd
+import tifffile
 from allensdk.core.reference_space_cache import ReferenceSpaceCache
 from bg_atlasapi import utils
-
-from bg_atlasgen.mesh_utils import create_region_mesh, Region
-from bg_atlasgen.wrapup import wrapup_atlas_from_data
 from bg_atlasapi.structure_tree_util import get_structures_tree
+from rich.progress import track
+from scipy.ndimage import zoom
+
+from bg_atlasgen.mesh_utils import Region, create_region_mesh
+from bg_atlasgen.wrapup import wrapup_atlas_from_data
 
 PARALLEL = False  # disable parallel mesh extraction for easier debugging
 
@@ -130,7 +129,6 @@ def create_atlas(working_dir, resolution):
     smooth = False  # smooth meshes after creation
     start = time.time()
     if PARALLEL:
-
         pool = mp.Pool(mp.cpu_count() - 2)
 
         try:

--- a/bg_atlasgen/atlas_scripts/perens_lsfm_mouse.py
+++ b/bg_atlasgen/atlas_scripts/perens_lsfm_mouse.py
@@ -1,32 +1,29 @@
 __version__ = "0"
 
 import json
-import time
-import tarfile
-import tifffile
-import subprocess
-
-import pandas as pd
-import numpy as np
 import multiprocessing as mp
-import SimpleITK as sitk
-
-from rich.progress import track
+import tarfile
+import time
 from pathlib import Path
-from scipy.ndimage import zoom
+
+import numpy as np
+import pandas as pd
+import SimpleITK as sitk
 
 # from allensdk.core.reference_space_cache import ReferenceSpaceCache
 from bg_atlasapi import utils
-
-from bg_atlasgen.mesh_utils import create_region_mesh, Region
-from bg_atlasgen.wrapup import wrapup_atlas_from_data
 from bg_atlasapi.structure_tree_util import get_structures_tree
+from rich.progress import track
+
+from bg_atlasgen.mesh_utils import Region, create_region_mesh
+from bg_atlasgen.wrapup import wrapup_atlas_from_data
 
 PARALLEL = False  # disable parallel mesh extraction for easier debugging
 
 
 # %%
 ### Additional functions #####################################################
+
 
 ##############################################################################
 def get_id_from_acronym(df, acronym):
@@ -146,7 +143,6 @@ def create_atlas(working_dir, resolution):
     CITATION = "Perens et al. 2021, https://doi.org/10.1007/s12021-020-09490-8"
     ORIENTATION = "rai"
     ROOT_ID = 997
-    ANNOTATIONS_RES_UM = 20
     ATLAS_FILE_URL = "https://github.com/Gubra-ApS/LSFM-mouse-brain-atlas/archive/master.tar.gz"
 
     # Temporary folder for  download:
@@ -252,7 +248,6 @@ def create_atlas(working_dir, resolution):
     closing_n_iters = 2
     start = time.time()
     if PARALLEL:
-
         pool = mp.Pool(mp.cpu_count() - 2)
 
         try:

--- a/bg_atlasgen/atlas_scripts/princeton_mouse.py
+++ b/bg_atlasgen/atlas_scripts/princeton_mouse.py
@@ -1,22 +1,22 @@
 __version__ = "0"
 __atlas__ = "princeton_mouse"
 
-import tifffile
+import json
+import multiprocessing as mp
 import os.path
+import time
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
-import json
-import time
-import multiprocessing as mp
-
-from rich.progress import track
-from pathlib import Path
+import tifffile
 from bg_atlasapi import utils
+from bg_atlasapi.structure_tree_util import get_structures_tree
+from rich.progress import track
 from scipy.ndimage import zoom
 
-from bg_atlasgen.mesh_utils import create_region_mesh, Region
+from bg_atlasgen.mesh_utils import Region, create_region_mesh
 from bg_atlasgen.wrapup import wrapup_atlas_from_data
-from bg_atlasapi.structure_tree_util import get_structures_tree
 
 PARALLEL = False
 
@@ -208,7 +208,7 @@ def create_atlas(working_dir, resolution):
     )
 
     # Wrap up, compress, and remove file:
-    print(f"Finalising atlas")
+    print("Finalising atlas")
     output_filename = wrapup_atlas_from_data(
         atlas_name=ATLAS_NAME,
         atlas_minor_version=__version__,

--- a/bg_atlasgen/atlas_scripts/whs_sd_rat.py
+++ b/bg_atlasgen/atlas_scripts/whs_sd_rat.py
@@ -13,7 +13,7 @@ from bg_atlasapi import utils
 from bg_atlasapi.structure_tree_util import get_structures_tree
 from rich.progress import track
 
-from bg_atlasgen.mesh_utils import create_region_mesh, Region
+from bg_atlasgen.mesh_utils import Region, create_region_mesh
 from bg_atlasgen.wrapup import wrapup_atlas_from_data
 
 PARALLEL = True
@@ -117,7 +117,6 @@ def create_meshes(download_dir_path, tree, annotated_volume, labels, root_id):
     smooth = False  # smooth meshes after creation
     start = time.time()
     if PARALLEL:
-
         pool = mp.Pool(min(mp.cpu_count() - 2, 16))
 
         try:

--- a/bg_atlasgen/main_script.py
+++ b/bg_atlasgen/main_script.py
@@ -1,15 +1,16 @@
-from git import Repo
-from git.exc import GitCommandError
-from pathlib import Path
 import configparser
-import bg_atlasgen
-from importlib import import_module
-from bg_atlasapi.utils import atlas_name_from_repr, atlas_repr_from_name
-
 import errno
 import os
-import stat
 import shutil
+import stat
+from importlib import import_module
+from pathlib import Path
+
+from bg_atlasapi.utils import atlas_name_from_repr, atlas_repr_from_name
+from git import Repo
+from git.exc import GitCommandError
+
+import bg_atlasgen
 
 # Main dictionary specifying which atlases to generate
 # and with which resolutions:
@@ -87,7 +88,6 @@ if __name__ == "__main__":
             bg_atlasgen_version == status["major_vers"]
             and script_version > status["minor_vers"]
         ):
-
             # Loop over all resolutions:
             for resolution in resolutions:
                 print(f"Generating {name}, {resolution} um...")

--- a/bg_atlasgen/mesh_utils.py
+++ b/bg_atlasgen/mesh_utils.py
@@ -1,5 +1,5 @@
 try:
-    from vedo import Mesh, write, load, show, Volume
+    from vedo import Mesh, Volume, load, show, write
     from vedo.applications import Browser, Slicer3DPlotter
 except ModuleNotFoundError:
     raise ModuleNotFoundError(
@@ -15,12 +15,13 @@ except ModuleNotFoundError:
         + '   please install with "pip install PyMCubes -U"'
     )
 
-from loguru import logger
-import numpy as np
 from pathlib import Path
-import scipy
-from bg_atlasgen.volume_utils import create_masked_array
 
+import numpy as np
+import scipy
+from loguru import logger
+
+from bg_atlasgen.volume_utils import create_masked_array
 
 # ---------------------------------------------------------------------------- #
 #                                 MESH CREATION                                #

--- a/bg_atlasgen/metadata_utils.py
+++ b/bg_atlasgen/metadata_utils.py
@@ -1,18 +1,18 @@
 """
-    Automatic creation of 
+    Automatic creation of
         . structures.csv
         . README.txt
 """
-import re
 import json
+import re
 from datetime import datetime
-from bg_atlasapi import descriptors
 
 import requests
-from requests.exceptions import MissingSchema, InvalidURL, ConnectionError
+from bg_atlasapi import descriptors
+from bg_atlasapi.structure_tree_util import get_structures_tree
+from requests.exceptions import ConnectionError, InvalidURL, MissingSchema
 
 from bg_atlasgen.structure_json_to_csv import convert_structure_json_to_csv
-from bg_atlasapi.structure_tree_util import get_structures_tree
 
 
 def generate_metadata_dict(
@@ -29,7 +29,6 @@ def generate_metadata_dict(
     additional_references,
     atlas_packager,
 ):
-
     # Name should be author_species
     assert len(name.split("_")) >= 2
 

--- a/bg_atlasgen/structure_json_to_csv.py
+++ b/bg_atlasgen/structure_json_to_csv.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 import pandas as pd
 
 

--- a/bg_atlasgen/test_git.py
+++ b/bg_atlasgen/test_git.py
@@ -1,5 +1,6 @@
-from git import Repo
 from pathlib import Path
+
+from git import Repo
 
 GENERATION_DICT = dict(example_mouse=[100])
 

--- a/bg_atlasgen/volume_utils.py
+++ b/bg_atlasgen/volume_utils.py
@@ -10,9 +10,9 @@ except ModuleNotFoundError:
         + '   please install with "pip install vedo -U"'
     )
 
-import imio
-
 import os
+
+import imio
 import numpy as np
 
 

--- a/bg_atlasgen/wrapup.py
+++ b/bg_atlasgen/wrapup.py
@@ -1,29 +1,26 @@
 import json
-import tarfile
 import shutil
+import tarfile
 from pathlib import Path
 
-import tifffile
 import bg_space as bgs
 import meshio as mio
+import tifffile
+from bg_atlasapi import descriptors
+from bg_atlasapi.utils import atlas_name_from_repr
 
+import bg_atlasgen
 from bg_atlasgen.metadata_utils import (
     create_metadata_files,
     generate_metadata_dict,
 )
 from bg_atlasgen.stacks import (
-    save_reference,
     save_annotation,
     save_hemispheres,
+    save_reference,
     save_secondary_reference,
 )
-
-import bg_atlasgen
 from bg_atlasgen.structures import check_struct_consistency
-
-from bg_atlasapi import descriptors
-from bg_atlasapi.utils import atlas_name_from_repr
-
 
 # This should be changed every time we make changes in the atlas
 # structure:
@@ -137,7 +134,6 @@ def wrapup_atlas_from_data(
 
     # write tiff stacks:
     for stack, saving_function in zip(stack_list, saving_fun_list):
-
         if isinstance(stack, str) or isinstance(stack, Path):
             stack = tifffile.imread(stack)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,4 +86,6 @@ ignore = [
 line-length = 79
 exclude = ["__init__.py","build",".eggs"]
 select = ["I", "E", "F"]
+# E501 Line too long
+ignore = ["E501"]
 fix = true


### PR DESCRIPTION
Adds the standard pre-commit config, and applies it to the codebase. There were *lots* of line too long errors, and I didn't particularly want to sit here fixing them all manually, so I've just ignored that error for now in the `ruff` configuration.