### PR TITLE
Turn off codecov comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: off


### PR DESCRIPTION
This turns off codecov commenting in PRs, in favour of the codecov status checks reported alongside the GH actions status.