### PR TITLE
scale mesh points before mapping to new anatomical space

### DIFF
--- a/bg_atlasgen/wrapup.py
+++ b/bg_atlasgen/wrapup.py
@@ -159,7 +159,7 @@ def wrapup_atlas_from_data(
         mesh = mio.read(meshfile)
 
         if scale_meshes:
-        # Scale the mesh to be in microns, BEFORE transforming:
+            # Scale the mesh to be in microns, BEFORE transforming:
             mesh.points *= resolution
 
         # Reorient points:

--- a/bg_atlasgen/wrapup.py
+++ b/bg_atlasgen/wrapup.py
@@ -158,14 +158,14 @@ def wrapup_atlas_from_data(
     for mesh_id, meshfile in meshes_dict.items():
         mesh = mio.read(meshfile)
 
+        if scale_meshes:
+        # Scale the mesh to be in microns, BEFORE transforming:
+            mesh.points *= resolution
+
         # Reorient points:
         mesh.points = space_convention.map_points_to(
             descriptors.ATLAS_ORIENTATION, mesh.points
         )
-
-        # Scale the mesh to be in microns, if necessary:
-        if scale_meshes:
-            mesh.points *= resolution
 
         # Save in meshes dir:
         mio.write(mesh_dest_dir / f"{mesh_id}.obj", mesh)

--- a/bg_atlasgen/wrapup.py
+++ b/bg_atlasgen/wrapup.py
@@ -159,7 +159,7 @@ def wrapup_atlas_from_data(
         mesh = mio.read(meshfile)
 
         if scale_meshes:
-            # Scale the mesh to be in microns, BEFORE transforming:
+            # Scale the mesh to the desired resolution, BEFORE transforming:
             mesh.points *= resolution
 
         # Reorient points:


### PR DESCRIPTION
## Description

**What is this PR**

- [x] Bug fix
- [ ] Addition of a new feature
- [ ] Other

**Why is this PR needed?**
Rat atlas and spinal cord meshes are not oriented correctly. See graph and text in #61 for deeper explanation.

**What does this PR do?**
Scales the mesh points before any `bg_space` transformation.

## References

Closes #61 
See also #60 and #51

## How has this PR been tested?

Manual testing by 
* generating rat atlas locally with changed code
* copy newly generated meshes folder
* paste this folder into my local rat atlas install.
* check for overlap in napari

Adding automated tests to this repo is an open and separate issue #13 .

## Is this a breaking change?

Nope

## Does this PR require an update to the documentation?

Nope

## Checklist:

- [x] The code has been tested locally
- [n/a] Tests have been added to cover all new functionality (unit & integration)
- [n/a] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
