### PR TITLE
simplify validation function

### DIFF
--- a/bg_atlasgen/validate_atlases.py
+++ b/bg_atlasgen/validate_atlases.py
@@ -10,13 +10,15 @@ from bg_atlasapi.config import get_brainglobe_dir
 from bg_atlasapi.list_atlases import (
     get_all_atlases_lastversions,
     get_atlases_lastversions,
+    get_local_atlas_version
 )
 from bg_atlasapi.update_atlases import update_atlas
 
 
-def validate_atlas_files(atlas_path: Path):
+def validate_atlas_files(atlas: BrainGlobeAtlas):
     """Checks if basic files exist in the atlas folder"""
 
+    atlas_path = Path(get_brainglobe_dir())/f"{atlas.atlas_name}_v{get_local_atlas_version(atlas.atlas_name)}"
     assert atlas_path.is_dir(), f"Atlas path {atlas_path} not found"
     expected_files = [
         "annotation.tiff",
@@ -90,28 +92,28 @@ def validate_mesh_matches_image_extents(atlas: BrainGlobeAtlas):
     return True
 
 
-def open_for_visual_check():
+def open_for_visual_check(atlas: BrainGlobeAtlas):
     # implement visual checks later
     pass
 
 
-def validate_checksum():
+def validate_checksum(atlas: BrainGlobeAtlas):
     # implement later
     pass
 
 
-def check_additional_references():
+def check_additional_references(atlas: BrainGlobeAtlas):
     # check additional references are different, but have same dimensions
     pass
 
 
-def validate_mesh_structure_pairs(atlas_name: str, atlas_path: Path):
-    # json_path = Path(atlas_path / "structures.json")
-    atlas = BrainGlobeAtlas(atlas_name)
+def validate_mesh_structure_pairs(atlas: BrainGlobeAtlas):
+    """Ensure mesh files (.obj) exist for each expected structure in the atlas."""
+    ids_from_bg_atlas_api = list(atlas.structures.keys())
 
+    atlas_path = Path(get_brainglobe_dir())/f"{atlas.atlas_name}_v{get_local_atlas_version(atlas.atlas_name)}"
     obj_path = Path(atlas_path / "meshes")
 
-    ids_from_bg_atlas_api = list(atlas.structures.keys())
     ids_from_mesh_files = [
         int(Path(file).stem)
         for file in os.listdir(obj_path)
@@ -135,7 +137,7 @@ def validate_mesh_structure_pairs(atlas_name: str, atlas_path: Path):
         )
 
 
-def validate_atlas(atlas_name, version, all_validation_functions):
+def validate_atlas(atlas_name, version, validation_functions):
     """Validates the latest version of a given atlas"""
 
     print(atlas_name, version)
@@ -144,34 +146,16 @@ def validate_atlas(atlas_name, version, all_validation_functions):
     if not updated:
         update_atlas(atlas_name)
 
-    validation_function_parameters = [
-        # validate_atlas_files(atlas_path: Path)
-        (Path(get_brainglobe_dir() / f"{atlas_name}_v{version}"),),
-        # validate_mesh_matches_image_extents(atlas: BrainGlobeAtlas)
-        (BrainGlobeAtlas(atlas_name),),
-        # open_for_visual_check()
-        (),
-        # validate_checksum()
-        (),
-        # check_additional_references()
-        (),
-        # validate_mesh_structure_pairs(atlas_name: str, atlas_path: Path):
-        (
-            atlas_name,
-            Path(get_brainglobe_dir() / f"{atlas_name}_v{version}"),
-        ),
-    ]
-
     # list to store the errors of the failed validations
-    failed_validations = []
-    successful_validations = []
+    failed_validations = {atlas_name: []}
+    successful_validations = {atlas_name: []}
 
-    for i, validation_function in enumerate(all_validation_functions):
+    for i, validation_function in enumerate(validation_functions):
         try:
-            validation_function(*validation_function_parameters[i])
-            successful_validations.append((atlas_name, validation_function))
+            validation_function(atlas_name)
+            successful_validations[atlas_name].append(validation_function)
         except AssertionError as error:
-            failed_validations.append((atlas_name, validation_function, error))
+            failed_validations[atlas_name].append((validation_function, error))
 
     return successful_validations, failed_validations
 

--- a/bg_atlasgen/validate_atlases.py
+++ b/bg_atlasgen/validate_atlases.py
@@ -10,7 +10,7 @@ from bg_atlasapi.config import get_brainglobe_dir
 from bg_atlasapi.list_atlases import (
     get_all_atlases_lastversions,
     get_atlases_lastversions,
-    get_local_atlas_version
+    get_local_atlas_version,
 )
 from bg_atlasapi.update_atlases import update_atlas
 
@@ -18,7 +18,10 @@ from bg_atlasapi.update_atlases import update_atlas
 def validate_atlas_files(atlas: BrainGlobeAtlas):
     """Checks if basic files exist in the atlas folder"""
 
-    atlas_path = Path(get_brainglobe_dir())/f"{atlas.atlas_name}_v{get_local_atlas_version(atlas.atlas_name)}"
+    atlas_path = (
+        Path(get_brainglobe_dir())
+        / f"{atlas.atlas_name}_v{get_local_atlas_version(atlas.atlas_name)}"
+    )
     assert atlas_path.is_dir(), f"Atlas path {atlas_path} not found"
     expected_files = [
         "annotation.tiff",
@@ -111,7 +114,10 @@ def validate_mesh_structure_pairs(atlas: BrainGlobeAtlas):
     """Ensure mesh files (.obj) exist for each expected structure in the atlas."""
     ids_from_bg_atlas_api = list(atlas.structures.keys())
 
-    atlas_path = Path(get_brainglobe_dir())/f"{atlas.atlas_name}_v{get_local_atlas_version(atlas.atlas_name)}"
+    atlas_path = (
+        Path(get_brainglobe_dir())
+        / f"{atlas.atlas_name}_v{get_local_atlas_version(atlas.atlas_name)}"
+    )
     obj_path = Path(atlas_path / "meshes")
 
     ids_from_mesh_files = [

--- a/bg_atlasgen/validate_atlases.py
+++ b/bg_atlasgen/validate_atlases.py
@@ -158,7 +158,7 @@ def validate_atlas(atlas_name, version, validation_functions):
 
     for i, validation_function in enumerate(validation_functions):
         try:
-            validation_function(atlas_name)
+            validation_function(BrainGlobeAtlas(atlas_name))
             successful_validations[atlas_name].append(validation_function)
         except AssertionError as error:
             failed_validations[atlas_name].append((validation_function, error))

--- a/tests/test_unit/test_validation.py
+++ b/tests/test_unit/test_validation.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import os
 
 import numpy as np
@@ -11,6 +10,7 @@ from bg_atlasgen.validate_atlases import (
     validate_atlas_files,
     validate_mesh_matches_image_extents,
 )
+
 
 @pytest.fixture
 def atlas():
@@ -25,11 +25,14 @@ def atlas_with_bad_reference_file():
     The atlas will have a misnamed template file that won't be found by the API
     This fixture also does the clean-up after the test has run
     """
-    good_name = get_brainglobe_dir()/"allen_mouse_100um_v1.2/reference.tiff"
-    bad_name = get_brainglobe_dir()/"allen_mouse_100um_v1.2/reference_bad.tiff"
+    good_name = get_brainglobe_dir() / "allen_mouse_100um_v1.2/reference.tiff"
+    bad_name = (
+        get_brainglobe_dir() / "allen_mouse_100um_v1.2/reference_bad.tiff"
+    )
     os.rename(good_name, bad_name)
     yield BrainGlobeAtlas("allen_mouse_100um")
     os.rename(bad_name, good_name)
+
 
 def test_validate_mesh_matches_image_extents(atlas):
     assert validate_mesh_matches_image_extents(atlas)
@@ -50,6 +53,7 @@ def test_validate_mesh_matches_image_extents_negative(mocker, atlas):
 
 def test_valid_atlas_files(atlas):
     assert validate_atlas_files(atlas)
+
 
 def test_invalid_atlas_path(atlas_with_bad_reference_file):
     with pytest.raises(AssertionError, match="Expected file not found"):

--- a/tests/test_unit/test_validation.py
+++ b/tests/test_unit/test_validation.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 
 import numpy as np
 import pytest
@@ -11,14 +12,30 @@ from bg_atlasgen.validate_atlases import (
     validate_mesh_matches_image_extents,
 )
 
+@pytest.fixture
+def atlas():
+    """A fixture providing a low-res Allen Mouse atlas for testing.
+    Tests assume this atlas is valid"""
+    return BrainGlobeAtlas("allen_mouse_100um")
 
-def test_validate_mesh_matches_image_extents():
-    atlas = BrainGlobeAtlas("allen_mouse_100um")
+
+@pytest.fixture
+def atlas_with_bad_reference_file():
+    """A fixture providing an invalid version of Allen Mouse atlas for testing.
+    The atlas will have a misnamed template file that won't be found by the API
+    This fixture also does the clean-up after the test has run
+    """
+    good_name = get_brainglobe_dir()/"allen_mouse_100um_v1.2/reference.tiff"
+    bad_name = get_brainglobe_dir()/"allen_mouse_100um_v1.2/reference_bad.tiff"
+    os.rename(good_name, bad_name)
+    yield BrainGlobeAtlas("allen_mouse_100um")
+    os.rename(bad_name, good_name)
+
+def test_validate_mesh_matches_image_extents(atlas):
     assert validate_mesh_matches_image_extents(atlas)
 
 
-def test_validate_mesh_matches_image_extents_negative(mocker):
-    atlas = BrainGlobeAtlas("allen_mouse_100um")
+def test_validate_mesh_matches_image_extents_negative(mocker, atlas):
     flipped_annotation_image = np.transpose(atlas.annotation)
     mocker.patch(
         "bg_atlasapi.BrainGlobeAtlas.annotation",
@@ -31,16 +48,12 @@ def test_validate_mesh_matches_image_extents_negative(mocker):
         validate_mesh_matches_image_extents(atlas)
 
 
-def test_valid_atlas_files():
-    _ = BrainGlobeAtlas("allen_mouse_100um")
-    atlas_path = Path(get_brainglobe_dir()) / "allen_mouse_100um_v1.2"
-    assert validate_atlas_files(atlas_path)
+def test_valid_atlas_files(atlas):
+    assert validate_atlas_files(atlas)
 
-
-def test_invalid_atlas_path():
-    atlas_path = Path.home()
+def test_invalid_atlas_path(atlas_with_bad_reference_file):
     with pytest.raises(AssertionError, match="Expected file not found"):
-        validate_atlas_files(atlas_path)
+        validate_atlas_files(atlas_with_bad_reference_file)
 
 
 def test_assert_close():


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**
New validation functions currently require a change in two places of the main validation script `validate_atlases.py`.

**What does this PR do?**
This PR makes all validation functions just take a single argument, which has to be atlas object - this is a requirement from now on. This means we don't need to build and maintain an ordered parameters list for each validation function in `validate_atlases.py`. Another advantage of this is that it simplifies mocking of atlas functions in the tests

This PR also simplify output list to be dicts of lists mapping the atlas name to values, so a possible output of a successful validations of atlas "allen_mouse_100um" would look like:
```python
{"allen_mouse_100um": [validation_function_1, validation_function_2]}
```
instead of
```python
[("allen_mouse_100um", validation_function_1), ("allen_mouse_100um", validation_function_2)]
```
reducing repetition.

## References

Closes #112 

## How has this PR been tested?

Existing tests have been adapted to fit new validation function signature.
Two new test fixtures have been added to reduce code length and increase flexibility.

## Is this a breaking change?
Yes, the signature of the validation functions has changed.

## Does this PR require an update to the documentation?
To be tackled in #93 

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
