### PR TITLE
test functions for validate_mesh_structure_pairs

### DIFF
--- a/bg_atlasgen/validate_atlases.py
+++ b/bg_atlasgen/validate_atlases.py
@@ -136,10 +136,14 @@ def validate_mesh_structure_pairs(atlas: BrainGlobeAtlas):
         if id not in ids_from_mesh_files:
             in_bg_not_mesh.append(id)
 
-    if len(in_mesh_not_bg) or len(in_bg_not_mesh):
+    if len(in_mesh_not_bg) != 0:
         raise AssertionError(
-            f"Structures with ID {in_bg_not_mesh} are in the atlas, but don't have a corresponding mesh file; "
             f"Structures with IDs {in_mesh_not_bg} have a mesh file, but are not accessible through the atlas."
+        )
+
+    if len(in_bg_not_mesh) != 0:
+        raise AssertionError(
+            f"Structures with IDs {in_bg_not_mesh} are in the atlas, but don't have a corresponding mesh file."
         )
 
 

--- a/bg_atlasgen/validate_atlases.py
+++ b/bg_atlasgen/validate_atlases.py
@@ -110,8 +110,37 @@ def check_additional_references(atlas: BrainGlobeAtlas):
     pass
 
 
-def validate_mesh_structure_pairs(atlas: BrainGlobeAtlas):
-    """Ensure mesh files (.obj) exist for each expected structure in the atlas."""
+def catch_missing_mesh_files(atlas: BrainGlobeAtlas):
+    """Checks if all the structures in the atlas have a corresponding mesh file"""
+
+    ids_from_bg_atlas_api = list(atlas.structures.keys())
+
+    atlas_path = (
+        Path(get_brainglobe_dir())
+        / f"{atlas.atlas_name}_v{get_local_atlas_version(atlas.atlas_name)}"
+    )
+    obj_path = Path(atlas_path / "meshes")
+
+    ids_from_mesh_files = [
+        int(Path(file).stem)
+        for file in os.listdir(obj_path)
+        if file.endswith(".obj")
+    ]
+
+    in_bg_not_mesh = []
+    for id in ids_from_bg_atlas_api:
+        if id not in ids_from_mesh_files:
+            in_bg_not_mesh.append(id)
+
+    if len(in_bg_not_mesh) != 0:
+        raise AssertionError(
+            f"Structures with IDs {in_bg_not_mesh} are in the atlas, but don't have a corresponding mesh file."
+        )
+
+
+def catch_missing_structures(atlas: BrainGlobeAtlas):
+    """Checks if all the mesh files in the atlas folder are listed as a structure in the atlas"""
+
     ids_from_bg_atlas_api = list(atlas.structures.keys())
 
     atlas_path = (
@@ -131,19 +160,9 @@ def validate_mesh_structure_pairs(atlas: BrainGlobeAtlas):
         if id not in ids_from_bg_atlas_api:
             in_mesh_not_bg.append(id)
 
-    in_bg_not_mesh = []
-    for id in ids_from_bg_atlas_api:
-        if id not in ids_from_mesh_files:
-            in_bg_not_mesh.append(id)
-
     if len(in_mesh_not_bg) != 0:
         raise AssertionError(
             f"Structures with IDs {in_mesh_not_bg} have a mesh file, but are not accessible through the atlas."
-        )
-
-    if len(in_bg_not_mesh) != 0:
-        raise AssertionError(
-            f"Structures with IDs {in_bg_not_mesh} are in the atlas, but don't have a corresponding mesh file."
         )
 
 
@@ -180,7 +199,8 @@ if __name__ == "__main__":
         open_for_visual_check,
         validate_checksum,
         check_additional_references,
-        validate_mesh_structure_pairs,
+        catch_missing_mesh_files,
+        catch_missing_structures,
     ]
 
     valid_atlases = []

--- a/tests/test_unit/test_validation.py
+++ b/tests/test_unit/test_validation.py
@@ -40,7 +40,7 @@ def atlas_with_bad_reference_file():
 def atlas_with_missing_structure():
     atlas = BrainGlobeAtlas("osten_mouse_100um")
     modified_structures = atlas.structures.copy()
-    modified_structures.pop(688, None)
+    modified_structures.pop(688)
 
     modified_atlas = BrainGlobeAtlas("osten_mouse_100um")
     modified_atlas.structures = modified_structures

--- a/tests/test_unit/test_validation.py
+++ b/tests/test_unit/test_validation.py
@@ -90,6 +90,10 @@ def test_validate_mesh_structure_pairs_no_obj(atlas):
 
 
 def test_validate_mesh_structure_pairs_not_in_atlas(atlas):
+    """
+        Tests if validate_mesh_structure_pairs function raises an error,
+        when there is at least one orphan obj file (doesn't have a corresponding structure in the atlas)
+    """
     with pytest.raises(
         AssertionError,
         match="Structures with IDs \[.*\] have a mesh file, but are not accessible through the atlas",

--- a/tests/test_unit/test_validation.py
+++ b/tests/test_unit/test_validation.py
@@ -7,9 +7,10 @@ from bg_atlasapi.config import get_brainglobe_dir
 
 from bg_atlasgen.validate_atlases import (
     _assert_close,
+    catch_missing_mesh_files,
+    catch_missing_structures,
     validate_atlas_files,
     validate_mesh_matches_image_extents,
-    validate_mesh_structure_pairs,
 )
 
 
@@ -72,31 +73,27 @@ def test_assert_close_negative():
         _assert_close(99.5, 30, 2)
 
 
-def test_validate_mesh_structure_pairs_no_obj(atlas):
+def test_catch_missing_mesh_files(atlas):
     """
-    Tests if validate_mesh_structure_pairs function raises an error,
+    Tests if catch_missing_mesh_files function raises an error,
     when there is at least one structure in the atlas that doesn't have
     a corresponding obj file.
 
     Expected behaviour:
     True for "allen_mouse_10um" (structure 545 doesn't have an obj file): fails
     the validation function, raises an error --> no output from this test function
-
-    False for "admba_3d_e11_5_mouse_16um" (it has all pairs): no error is
-    raised by the validation function --> this test function catches it
     """
 
     with pytest.raises(
         AssertionError,
-        # match=r"Structures with IDs \[.*?\] are in the atlas, but don't have a corresponding mesh file.",
-        match=r"\[.*?\]",
+        match=r"Structures with IDs \[.*?\] are in the atlas, but don't have a corresponding mesh file.",
     ):
-        validate_mesh_structure_pairs(atlas)
+        catch_missing_mesh_files(atlas)
 
 
-def test_validate_mesh_structure_pairs_not_in_atlas(atlas):
+def test_catch_missing_structures(atlas):
     """
-    Tests if validate_mesh_structure_pairs function raises an error,
+    Tests if catch_missing_structures function raises an error,
     when there is at least one orphan obj file (doesn't have a corresponding structure in the atlas)
 
     Expected behaviour:
@@ -106,9 +103,6 @@ def test_validate_mesh_structure_pairs_not_in_atlas(atlas):
 
     with pytest.raises(
         AssertionError,
-        # match=r"Structures with IDs \[.*?\] have a mesh file, but are not accessible through the atlas.",
-        # Only checks if there's anything in the []. If there isn't --> error
-        # It runs without an error with "allen_mouse_10um" as it fills the []
-        match=r"\[.*?\]",
+        match=r"Structures with IDs \[.*?\] have a mesh file, but are not accessible through the atlas.",
     ):
-        validate_mesh_structure_pairs(atlas)
+        catch_missing_structures(atlas)

--- a/tests/test_unit/test_validation.py
+++ b/tests/test_unit/test_validation.py
@@ -88,7 +88,7 @@ def test_validate_mesh_structure_pairs_no_obj(atlas):
 
     with pytest.raises(
         AssertionError,
-        #match=r"Structures with IDs \[.*?\] are in the atlas, but don't have a corresponding mesh file.",
+        # match=r"Structures with IDs \[.*?\] are in the atlas, but don't have a corresponding mesh file.",
         match=r"\[.*?\]",
     ):
         validate_mesh_structure_pairs(atlas)
@@ -106,8 +106,7 @@ def test_validate_mesh_structure_pairs_not_in_atlas(atlas):
 
     with pytest.raises(
         AssertionError,
-        #match=r"Structures with IDs \[.*?\] have a mesh file, but are not accessible through the atlas.",
-
+        # match=r"Structures with IDs \[.*?\] have a mesh file, but are not accessible through the atlas.",
         # Only checks if there's anything in the []. If there isn't --> error
         # It runs without an error with "allen_mouse_10um" as it fills the []
         match=r"\[.*?\]",

--- a/tests/test_unit/test_validation.py
+++ b/tests/test_unit/test_validation.py
@@ -71,6 +71,7 @@ def test_assert_close_negative():
     ):
         _assert_close(99.5, 30, 2)
 
+
 def test_validate_mesh_structure_pairs_no_obj(atlas):
     """
     Tests if validate_mesh_structure_pairs function raises an error,
@@ -82,12 +83,15 @@ def test_validate_mesh_structure_pairs_no_obj(atlas):
 
     """
     with pytest.raises(
-        AssertionError, match="Structures with ID \[.*\] are in the atlas, but don't have a corresponding mesh file"
+        AssertionError,
+        match="Structures with ID \[.*\] are in the atlas, but don't have a corresponding mesh file",
     ):
         validate_mesh_structure_pairs(atlas)
 
+
 def test_validate_mesh_structure_pairs_not_in_atlas(atlas):
     with pytest.raises(
-        AssertionError, match="Structures with IDs \[.*\] have a mesh file, but are not accessible through the atlas"
+        AssertionError,
+        match="Structures with IDs \[.*\] have a mesh file, but are not accessible through the atlas",
     ):
         validate_mesh_structure_pairs(atlas)

--- a/tests/test_unit/test_validation.py
+++ b/tests/test_unit/test_validation.py
@@ -36,6 +36,17 @@ def atlas_with_bad_reference_file():
     os.rename(bad_name, good_name)
 
 
+@pytest.fixture
+def atlas_with_missing_structure():
+    atlas = BrainGlobeAtlas("osten_mouse_100um")
+    modified_structures = atlas.structures.copy()
+    modified_structures.pop(688, None)
+
+    modified_atlas = BrainGlobeAtlas("osten_mouse_100um")
+    modified_atlas.structures = modified_structures
+    return modified_atlas
+
+
 def test_validate_mesh_matches_image_extents(atlas):
     assert validate_mesh_matches_image_extents(atlas)
 
@@ -91,7 +102,7 @@ def test_catch_missing_mesh_files(atlas):
         catch_missing_mesh_files(atlas)
 
 
-def test_catch_missing_structures(atlas):
+def test_catch_missing_structures(atlas_with_missing_structure):
     """
     Tests if catch_missing_structures function raises an error,
     when there is at least one orphan obj file (doesn't have a corresponding structure in the atlas)
@@ -105,4 +116,4 @@ def test_catch_missing_structures(atlas):
         AssertionError,
         match=r"Structures with IDs \[.*?\] have a mesh file, but are not accessible through the atlas.",
     ):
-        catch_missing_structures(atlas)
+        catch_missing_structures(atlas_with_missing_structure)

--- a/tests/test_unit/test_validation.py
+++ b/tests/test_unit/test_validation.py
@@ -84,11 +84,12 @@ def test_validate_mesh_structure_pairs_no_obj(atlas):
 
     False for "admba_3d_e11_5_mouse_16um" (it has all pairs): no error is
     raised by the validation function --> this test function catches it
-
     """
+
     with pytest.raises(
         AssertionError,
-        match=r"Structures with ID \[.*?\] are in the atlas, but don't have a corresponding mesh file;",
+        #match=r"Structures with IDs \[.*?\] are in the atlas, but don't have a corresponding mesh file.",
+        match=r"\[.*?\]",
     ):
         validate_mesh_structure_pairs(atlas)
 
@@ -102,8 +103,13 @@ def test_validate_mesh_structure_pairs_not_in_atlas(atlas):
     Currently no atlas fails the validation function this way so the [] is always empty
     --> this test function should always raise an error
     """
+
     with pytest.raises(
         AssertionError,
-        match=r"Structures with IDs \[.*?\] have a mesh file, but are not accessible through the atlas.",
+        #match=r"Structures with IDs \[.*?\] have a mesh file, but are not accessible through the atlas.",
+
+        # Only checks if there's anything in the []. If there isn't --> error
+        # It runs without an error with "allen_mouse_10um" as it fills the []
+        match=r"\[.*?\]",
     ):
         validate_mesh_structure_pairs(atlas)

--- a/tests/test_unit/test_validation.py
+++ b/tests/test_unit/test_validation.py
@@ -78,13 +78,17 @@ def test_validate_mesh_structure_pairs_no_obj(atlas):
     when there is at least one structure in the atlas that doesn't have
     a corresponding obj file.
 
-    True for: allen_mouse_100um (structure 545 doesn't have an obj file)
-    False for: admba_3d_e11_5_mouse_16um (it has all pairs)
+    Expected behaviour:
+    True for "allen_mouse_10um" (structure 545 doesn't have an obj file): fails
+    the validation function, raises an error --> no output from this test function
+
+    False for "admba_3d_e11_5_mouse_16um" (it has all pairs): no error is
+    raised by the validation function --> this test function catches it
 
     """
     with pytest.raises(
         AssertionError,
-        match="Structures with ID \[.*\] are in the atlas, but don't have a corresponding mesh file",
+        match=r"Structures with ID \[.*?\] are in the atlas, but don't have a corresponding mesh file;",
     ):
         validate_mesh_structure_pairs(atlas)
 
@@ -93,9 +97,13 @@ def test_validate_mesh_structure_pairs_not_in_atlas(atlas):
     """
     Tests if validate_mesh_structure_pairs function raises an error,
     when there is at least one orphan obj file (doesn't have a corresponding structure in the atlas)
+
+    Expected behaviour:
+    Currently no atlas fails the validation function this way so the [] is always empty
+    --> this test function should always raise an error
     """
     with pytest.raises(
         AssertionError,
-        match="Structures with IDs \[.*\] have a mesh file, but are not accessible through the atlas",
+        match=r"Structures with IDs \[.*?\] have a mesh file, but are not accessible through the atlas.",
     ):
         validate_mesh_structure_pairs(atlas)

--- a/tests/test_unit/test_validation.py
+++ b/tests/test_unit/test_validation.py
@@ -9,6 +9,7 @@ from bg_atlasgen.validate_atlases import (
     _assert_close,
     validate_atlas_files,
     validate_mesh_matches_image_extents,
+    validate_mesh_structure_pairs,
 )
 
 
@@ -69,3 +70,24 @@ def test_assert_close_negative():
         AssertionError, match="differ by more than 10 times pixel size"
     ):
         _assert_close(99.5, 30, 2)
+
+def test_validate_mesh_structure_pairs_no_obj(atlas):
+    """
+    Tests if validate_mesh_structure_pairs function raises an error,
+    when there is at least one structure in the atlas that doesn't have
+    a corresponding obj file.
+
+    True for: allen_mouse_100um (structure 545 doesn't have an obj file)
+    False for: admba_3d_e11_5_mouse_16um (it has all pairs)
+
+    """
+    with pytest.raises(
+        AssertionError, match="Structures with ID \[.*\] are in the atlas, but don't have a corresponding mesh file"
+    ):
+        validate_mesh_structure_pairs(atlas)
+
+def test_validate_mesh_structure_pairs_not_in_atlas(atlas):
+    with pytest.raises(
+        AssertionError, match="Structures with IDs \[.*\] have a mesh file, but are not accessible through the atlas"
+    ):
+        validate_mesh_structure_pairs(atlas)

--- a/tests/test_unit/test_validation.py
+++ b/tests/test_unit/test_validation.py
@@ -91,8 +91,8 @@ def test_validate_mesh_structure_pairs_no_obj(atlas):
 
 def test_validate_mesh_structure_pairs_not_in_atlas(atlas):
     """
-        Tests if validate_mesh_structure_pairs function raises an error,
-        when there is at least one orphan obj file (doesn't have a corresponding structure in the atlas)
+    Tests if validate_mesh_structure_pairs function raises an error,
+    when there is at least one orphan obj file (doesn't have a corresponding structure in the atlas)
     """
     with pytest.raises(
         AssertionError,


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other

**Why is this PR needed?**

To complete `validate_mesh_structure_pairs` function with test functions.

**What does this PR do?**

Adds test functions for `validate_mesh_structure_pairs` validation function in `validate_atlases.py`.


## References

closes #111 

## How has this PR been tested?

Test functions have been tested manually using `BrainGlobeAtlas("allen_mouse_100um")` and `BrainGlobeAtlas("admba_3d_e11_5_mouse_16u")`

## Is this a breaking change?

No

## Does this PR require an update to the documentation?

No

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
